### PR TITLE
Add some flexibility to scripts

### DIFF
--- a/ec2-refresh
+++ b/ec2-refresh
@@ -1,5 +1,13 @@
 #!/bin/sh
 # Look for all ec2 instances run by user $LOGNAME and cache them in $FILE:
+region=${region-$aws}
+
+if [ -n "$region" ]; then
+    region="--region $region"
+else
+    region=""
+fi
+
 logname=`logname`
 FILE=/tmp/ec2-instances-$logname
-aws ec2 describe-instances --filters "Name=tag:RunByUser,Values=$logname" >$FILE
+aws $region ec2 describe-instances --filters "Name=tag:RunByUser,Values=$logname" >$FILE

--- a/ssh1
+++ b/ssh1
@@ -74,7 +74,7 @@ wait
 #   mvn -pl site.ycsb:dynamodb-binding -am clean package -DskipTests
 #   mkdir OUT
 #   tar zxvf dynamodb/target/ycsb-dynamodb-binding* -C OUT --strip-components 1
-MY_YCSB_DIR=/home/nyh/YCSB/OUT
+MY_YCSB_DIR=${MY_YCSB_DIR-/home/nyh/YCSB/OUT}
 YCSB="cd ycsb; bin/ycsb"
 for loader in ${loaders[@]}
 do

--- a/ssh1
+++ b/ssh1
@@ -95,14 +95,15 @@ case $aws in
     ;;
 esac
 
+AWS_CMD="aws --region $aws"
 # Create the test table "usertable" (deleting it first if it exists)
 # FIXME: need to delete the table without snapshots, which just wastes
 # time on the server! If we can't configure Scylla properly, at least
 # ssh to the server and delete the snapshots :-(
-aws dynamodb delete-table \
+$AWS_CMD dynamodb delete-table \
     --endpoint-url $scylla_api \
     --table-name usertable || :
-aws dynamodb wait table-not-exists \
+$AWS_CMD dynamodb wait table-not-exists \
     --endpoint-url $scylla_api \
     --table-name usertable
 # set "wcu" (write capacity units) to create the table in provisioned billing
@@ -113,7 +114,7 @@ then
 else
     billing_mode="--billing-mode PAY_PER_REQUEST"
 fi
-aws dynamodb create-table \
+$AWS_CMD dynamodb create-table \
     --endpoint-url $scylla_api \
     --table-name usertable \
     --attribute-definitions \
@@ -122,7 +123,7 @@ aws dynamodb create-table \
         AttributeName=p,KeyType=HASH \
     $billing_mode \
     --tags Key=system:write_isolation,Value=$isolation
-aws dynamodb wait table-exists \
+$AWS_CMD dynamodb wait table-exists \
     --endpoint-url $scylla_api \
     --table-name usertable
 
@@ -221,7 +222,7 @@ case $aws in
 *)  # AWS
     # On AWS, delete the table so we don't continue to pay a fortune for it
     # if it is a provisioned table!
-    aws dynamodb delete-table \
+    $AWS_CMD dynamodb delete-table \
         --endpoint-url $scylla_api \
         --table-name usertable || :
     ;;


### PR DESCRIPTION
The script assumed (probably accidently) that the default region set up in the aws cli tool is the region worked on.
This is not always true.
Also the existance of a specific YCSB folder location was assumed.
This simply fixes those :slightly_smiling_face: 